### PR TITLE
Fix “framless” typo

### DIFF
--- a/src/include/_Grid.pug
+++ b/src/include/_Grid.pug
@@ -76,7 +76,7 @@ section.grid
       .flexi.d-four.t-six.mix.frameless
         .grid-item(data-src='frameless/FramelessGrid').frameless.new
           img(src='images/categories/frameless.svg')
-          span.title Framless Grids
+          span.title Frameless Grids
           small.info 3 Templates - 443 KB
     
     include _GridEnd.pug


### PR DESCRIPTION
I saw there was a minor typo on the index page. 